### PR TITLE
Ensure Statistical Invariance to Tensor Parallelism

### DIFF
--- a/src/climate_learn/models/hub/components/mlp.py
+++ b/src/climate_learn/models/hub/components/mlp.py
@@ -111,9 +111,6 @@ class GluMlp(nn.Module):
         super().__init__()
         out_features = out_features or in_features
         hidden_features = hidden_features or in_features
-        self.in_features = in_features
-        self.hidden_features = hidden_features
-        self.out_features = out_features
         assert hidden_features % 2 == 0
         bias = to_2tuple(bias)
         drop_probs = to_2tuple(drop)
@@ -127,7 +124,6 @@ class GluMlp(nn.Module):
         self.norm = norm_layer(hidden_features // 2) if norm_layer is not None else nn.Identity()
         self.fc2 = linear_layer(hidden_features // 2, out_features, bias=bias[1])
         self.drop2 = nn.Dropout(drop_probs[1])
-        self.init_weights()
 
     def init_weights(self):
         # override init of fc1 w/ gate portion set to weight near zero, bias=1


### PR DESCRIPTION
@XiaoWang-Github 
By default, PyTorch initializes `nn.Linear()` weights and biases with a statistical distribution parametrized by the input dimension ([link](https://docs.pytorch.org/docs/stable/generated/torch.nn.Linear)). Tensor parallelism will distort this initialization by only revealing the local dimension of (`dim // tensor_par_size`).

By correctly re-initializing the parameters to account for the `tensor_par_size`, there should be more statistical stability in activations and gradients, making for better training.

I unfortunately haven't been able to test these changes since I don't use conda after the licensing changes; discussion could follow on how is easiest/best to validate the proposed changes.

Black reformatted much of the `attention.py` and `mlp.py` files and I'm not sure whether to push that - should I be using any particular version of black?